### PR TITLE
Chart view only mode

### DIFF
--- a/global-components/ChartEditor.vue
+++ b/global-components/ChartEditor.vue
@@ -1,14 +1,19 @@
 <template>
   <div class="chart-editor">
+    <span>
+      chartOnly: {{ chartOnly }}
+    </span>
     <chart-view
       ref="chart-view"
       :config="config"
     />
     <chart-actions
+      v-if="!chartOnly"
       :actions="actions"
       @action="execute"
     />
     <code-editor
+      v-if="!chartOnly"
       :error.sync="error"
       :messages="messages"
       :output="output"
@@ -46,6 +51,7 @@ export default {
     error: null,
     messages: [],
     output: false,
+    chartOnly: false
   }),
 
   watch: {
@@ -101,6 +107,7 @@ export default {
         const exports = new Function(script)(context);
         const config = exports.config || null;
         this.output = exports.output || false;
+        this.chartOnly = exports.chartOnly || false;
 
         if (!this.actions) {
           this.actions = exports.actions || null;

--- a/global-components/ChartEditor.vue
+++ b/global-components/ChartEditor.vue
@@ -1,8 +1,5 @@
 <template>
   <div class="chart-editor">
-    <span>
-      chartOnly: {{ chartOnly }}
-    </span>
     <chart-view
       ref="chart-view"
       :config="config"


### PR DESCRIPTION
I've been working on an [update](https://github.com/chartjs/Chart.js/pull/10816) to Chart.js docs and wanted to have a component that would render a chart but wouldn't show the code editor (as suggested by @LeeLenaleee).

This PR only renders the chart by passing the `chartOnly` option.